### PR TITLE
Add `X-Cors-Proxy-Allowed-Request-Headers` header if USE_PLAYGROUND_C…

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -142,6 +142,16 @@ class Client {
 			$args['body'] = \wp_json_encode( $data );
 		}
 
+		/**
+		 * Use Playground CORS proxy.
+		 *
+		 * @link https://github.com/pronamic/wp-pronamic-pay/issues/421#issuecomment-3184267100
+		 * @link https://github.com/WordPress/wordpress-playground/pull/2007
+		 */
+		if ( defined( 'USE_PLAYGROUND_CORS_PROXY' ) && true === USE_PLAYGROUND_CORS_PROXY ) {
+			$args['headers']['X-Cors-Proxy-Allowed-Request-Headers'] = 'Authorization';
+		}
+
 		$response = Http::request( $url, $args );
 
 		$data = $response->json();

--- a/src/Client.php
+++ b/src/Client.php
@@ -148,7 +148,7 @@ class Client {
 		 * @link https://github.com/pronamic/wp-pronamic-pay/issues/421#issuecomment-3184267100
 		 * @link https://github.com/WordPress/wordpress-playground/pull/2007
 		 */
-		if ( defined( 'USE_PLAYGROUND_CORS_PROXY' ) && true === USE_PLAYGROUND_CORS_PROXY ) {
+		if ( \defined( 'USE_PLAYGROUND_CORS_PROXY' ) && true === \USE_PLAYGROUND_CORS_PROXY ) {
 			$args['headers']['X-Cors-Proxy-Allowed-Request-Headers'] = 'Authorization';
 		}
 


### PR DESCRIPTION
Add `X-Cors-Proxy-Allowed-Request-Headers` header if `USE_PLAYGROUND_CORS_PROXY` is defined and true, in combination with https://github.com/pronamic/wp-pronamic-pay/commit/c66dd51465093322adca75f6f4dc0c6625f7cda0.